### PR TITLE
MerkleTree: fix a bug in verify()

### DIFF
--- a/src/helpers/MerkleTree.js
+++ b/src/helpers/MerkleTree.js
@@ -72,7 +72,7 @@ export default class MerkleTree {
   }
 
   verify (proof, element) {
-    return this.root.equals(
+    return this.getRoot().equals(
       proof.reduce((hash, pair) => combinedHash(hash, pair), element)
     )
   }


### PR DESCRIPTION
`verify()` assumes `getRoot()` has been previously invoked and uses `this.root` directly

apparently, there's no case in this repo where it hasn't been, but it's a bug nonetheless